### PR TITLE
Dropped requirement to have a reference substatement for revision.

### DIFF
--- a/plugins/arrcus.py
+++ b/plugins/arrcus.py
@@ -57,7 +57,6 @@ _required_substatements = {
                "RFC 8407: 4.8"),
     'submodule': (('contact', 'organization', 'description', 'revision'),
                   "RFC 8407: 4.8"),
-    'revision':(('reference',), "RFC 8407: 4.8"),
     'extension':(('description',), "RFC 8407: 4.14"),
     'feature':(('description',), "RFC 8407: 4.14"),
     'identity':(('description',), "RFC 8407: 4.14"),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='pyang-arrcus-plugin',
-    version='0.1',
+    version='0.5',
     description=('A pyang plugin to validate Arrcus native models'),
     long_description=read('README.md'),
     packages=['plugins'],
@@ -14,8 +14,8 @@ setup(
     author_email='mjethanandani@gmail.com',
     license='New-style BSD',
     url='https://github.com/mjethanandani/pyang-arrcus-plugin',
-    download_url='https://github.com/mjethanandani/pyang-arrcus-plugin/archive/0.1.tar.gz',
-    install_requires=['pyang>=1.7.1'],
+    download_url='https://github.com/mjethanandani/pyang-arrcus-plugin/archive/0.5.tar.gz',
+    install_requires=['pyang>=2.5.3'],
     include_package_data=True,
     keywords=['yang', 'validation'],
     classifiers=[],


### PR DESCRIPTION
Not all modules need to have a reference sub-statement for revision statement. Removing that check.